### PR TITLE
Enable automatic Nix store optimization for macOS hosts

### DIFF
--- a/hosts/darwin.nix
+++ b/hosts/darwin.nix
@@ -25,6 +25,7 @@ with lib.my;
   config = {
     nix = {
       package = pkgs.nixVersions.latest;
+      settings.auto-optimise-store = true;
       extraOptions = ''
         extra-platforms = x86_64-darwin aarch64-darwin
         experimental-features = nix-command flakes


### PR DESCRIPTION
This PR enables automatic Nix store optimization for macOS hosts by setting `nix.settings.auto-optimise-store = true`. This helps reduce disk space usage by automatically detecting and removing duplicate files in the Nix store, replacing them with hard links to a single copy.

Fixes #2

Generated with [Claude Code](https://claude.ai/code)